### PR TITLE
Increment(?) code coverage and use unittest assertions for better messaging

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -145,6 +145,27 @@ This option can be overridden with every request or subwrap::
     api.special.endpoint.get(extension='xml')
 
 
+URL Suffix
+~~~~~~~~~~
+
+Some APIs uses a trailling slash at the end of URLs like in example below::
+
+  https://api.example.org/resource/
+
+You can add the trailling slash with ``suffix="/"`` argument when wrapping
+the API or getting the URL with ``.url(suffix="/")`` method::
+
+    api = tortilla.wrap('https://api.example.org', suffix="/")
+    api.video(71).comments.url()
+
+Will return the following URL::
+
+    api         -> https://api.example.org
+    .video      -> /video
+    (id)        -> /71/
+    Final URL   -> https://api.example.org/video/71/
+
+
 Debugging
 ~~~~~~~~~
 

--- a/test_tortilla.py
+++ b/test_tortilla.py
@@ -12,6 +12,10 @@ import httpretty
 from requests.exceptions import HTTPError
 
 import tortilla
+from tortilla.utils import bunchify, Bunch, run_from_ipython
+
+
+API_URL = 'https://test.tortilla.locally'
 
 
 def monkey_patch_httpretty():
@@ -31,132 +35,149 @@ if sys.version_info[0] == 2:
     monkey_patch_httpretty()
 
 
-API_URL = 'https://test.tortilla.locally'
-api = tortilla.wrap(API_URL)
-
-
-def register_urls(urls):
-    for endpoint, options in urls.items():
-        if isinstance(options.get('body'), (dict, list, tuple)):
-            body = json.dumps(options.get('body'))
-        else:
-            body = options.get('body')
-        httpretty.register_uri(method=options.get('method', 'GET'),
-                               status=options.get('status', 200),
-                               uri=API_URL + endpoint,
-                               body=body)
-
-
-with open('test_data.json') as resource:
-    test_data = json.load(resource)
-endpoints = test_data['endpoints']
-register_urls(endpoints)
-
-# this is a special endpoint which loops through responses,
-# very useful to test the cache
-httpretty.register_uri(
-    httpretty.GET, API_URL + '/cache',
-    responses=[
-        httpretty.Response(body='"cache this response"'),
-        httpretty.Response(body='"this should not be returned"'),
-    ]
-)
-
-
-def time_function(func, *args, **kwargs):
-    """Returns the time it took for a function to execute."""
-    start = time.time()
-    func(*args, **kwargs)
-    return time.time() - start
-
-
 class TestTortilla(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # this is a special endpoint which loops through responses,
+        # very useful to test the cache
+        httpretty.register_uri(
+            httpretty.GET, API_URL + '/cache',
+            responses=[
+                httpretty.Response(body='"cache this response"'),
+                httpretty.Response(body='"this should not be returned"'),
+            ]
+        )
+
+        with open('test_data.json') as resource:
+            test_data = json.load(resource)
+
+        cls.endpoints = test_data['endpoints']
+
+        for endpoint, options in cls.endpoints.items():
+            if isinstance(options.get('body'), (dict, list, tuple)):
+                body = json.dumps(options.get('body'))
+            else:
+                body = options.get('body')
+
+            httpretty.register_uri(method=options.get('method', 'GET'),
+                                   status=options.get('status', 200),
+                                   uri=API_URL + endpoint,
+                                   body=body)
+
     def setUp(self):
         httpretty.enable()
+        self.api = tortilla.wrap(API_URL)
 
     def tearDown(self):
         httpretty.disable()
 
+    def _time_function(self, func, *args, **kwargs):
+        """Returns the time it took for a function to execute."""
+        start = time.time()
+        func(*args, **kwargs)
+        return time.time() - start
+
     def test_json_response(self):
-        assert api.user.get('jimmy') == endpoints['/user/jimmy']['body']
-        assert api.user.get('имя') == endpoints['/user/имя']['body']
-        assert api.has_self.get() == endpoints['/has_self']['body']
+        self.assertEqual(self.api.user.get('jimmy'),
+                         self.endpoints['/user/jimmy']['body'])
+        self.assertEqual(self.api.user.get('имя'),
+                         self.endpoints['/user/имя']['body'])
+        self.assertEqual(self.api.has_self.get(),
+                         self.endpoints['/has_self']['body'])
 
     def test_non_json_response(self):
-        self.assertRaises(ValueError, api.nojson.get)
-        assert api.nojson.get(silent=True) is None
+        with self.assertRaises(ValueError):
+            self.api.nojson.get()
+        self.assertIsNone(self.api.nojson.get(silent=True))
 
     def test_formed_urls(self):
-        assert api.this.url() == API_URL + '/this'
-        assert api('this').url() == API_URL + '/this'
-        assert api.this('that').url() == API_URL + '/this/that'
-        assert api('this')('that').url() == API_URL + '/this/that'
-        assert api.user('имя').url() == API_URL + '/user/имя'
+        self.assertEquals(self.api.this.url(), API_URL + '/this')
+        self.assertEquals(self.api('this').url(), API_URL + '/this')
+        self.assertEquals(self.api.this('that').url(), API_URL + '/this/that')
+        self.assertEquals(self.api('this')('that').url(), API_URL + '/this/that')
+        self.assertEquals(self.api.user('имя').url(), API_URL + '/user/имя')
+        self.assertEquals(self.api('hello', 'world').url(), API_URL + '/hello/world')
+        self.assertEquals(self.api('products', 123).url(), API_URL + '/products/123')
+
         trailing_slash_api = tortilla.wrap(API_URL + '/')
-        assert trailing_slash_api.endpoint.url() == API_URL + '/endpoint'
-        assert api('hello', 'world').url() == API_URL + '/hello/world'
-        assert api('products', 123).url() == API_URL + '/products/123'
+        self.assertEquals(trailing_slash_api.endpoint.url(), API_URL + '/endpoint')
 
     def test_cached_response(self):
-        api.cache.get(cache_lifetime=100)
-        assert api.cache.get() == "cache this response"
-        api.cache.get(cache_lifetime=0.25, ignore_cache=True)
+        self.api.cache.get(cache_lifetime=100)
+        self.assertEquals(self.api.cache.get(), "cache this response")
+
+        self.api.cache.get(cache_lifetime=0.25, ignore_cache=True)
         time.sleep(0.5)
-        assert api.cache.get() == "this should not be returned"
+        self.assertEquals(self.api.cache.get(), "this should not be returned")
 
     def test_request_delay(self):
-        api.config.delay = 0.5
-        api.test.get()
-        assert time_function(api.test.get) >= 0.5
-        assert time_function(api.test.get, delay=0.1) >= 0.1
-        assert time_function(api.test.get) >= 0.5
+        self.api.config.delay = 0.5
+        self.api.test.get()
+        self.assertGreaterEqual(self._time_function(self.api.test.get), 0.5)
+        self.assertGreaterEqual(self._time_function(self.api.test.get, delay=0.1), 0.1)
+        self.assertGreaterEqual(self._time_function(self.api.test.get), 0.5)
+
         # do not delay the rest of the tests
-        api.config.delay = 0
+        self.api.config.delay = 0
 
     def test_request_methods(self):
-        assert api.awesome.tweet.post().message == "Success!"
-        assert api.cash.money.put().message == "Success!"
-        assert api.windows.ssh.patch().message == "Success!"
-        assert api.world.hunger.delete().message == "Success!"
-        assert api.another.test.head() is None
+        self.assertEquals(self.api.awesome.tweet.post().message, "Success!")
+        self.assertEquals(self.api.cash.money.put().message, "Success!")
+        self.assertEquals(self.api.windows.ssh.patch().message, "Success!")
+        self.assertEquals(self.api.world.hunger.delete().message, "Success!")
+        self.assertIsNone(self.api.another.test.head())
 
     def test_extensions(self):
-        assert api.extension.hello.get(extension='json').message == 'Success!'
-        assert api.extension.hello.get(extension='.json').message == 'Success!'
+        self.assertEquals(self.api.extension.hello.get(extension='json').message, 'Success!')
+        self.assertEquals(self.api.extension.hello.get(extension='.json').message, 'Success!')
 
     def test_wrap_config(self):
-        api.stuff(debug=True, extension='json', cache_lifetime=5, silent=True)
-        assert api.stuff.config.debug
-        assert api.stuff.config.extension == 'json'
-        assert api.stuff.config.cache_lifetime == 5
-        assert api.stuff.config.silent
-        api.stuff(debug=False, extension='xml', cache_lifetime=8, silent=False)
-        assert not api.stuff.config.debug
-        assert api.stuff.config.extension == 'xml'
-        assert api.stuff.config.cache_lifetime == 8
-        assert not api.stuff.config.silent
-        api.stuff('more', 'stuff', debug=True)
-        assert api.stuff.config.debug
+        self.api.stuff(debug=True, extension='json', cache_lifetime=5, silent=True)
+        self.assertTrue(self.api.stuff.config.debug)
+        self.assertEquals(self.api.stuff.config.extension, 'json')
+        self.assertEquals(self.api.stuff.config.cache_lifetime, 5)
+        self.assertTrue(self.api.stuff.config.silent)
+
+        self.api.stuff(debug=False, extension='xml', cache_lifetime=8, silent=False)
+        self.assertFalse(self.api.stuff.config.debug)
+        self.assertEquals(self.api.stuff.config.extension, 'xml')
+        self.assertEquals(self.api.stuff.config.cache_lifetime, 8)
+        self.assertFalse(self.api.stuff.config.silent)
+
+        self.api.stuff('more', 'stuff', debug=True)
+        self.assertTrue(self.api.stuff.config.debug)
 
     def test_wrap_chain(self):
-        assert api.chained.wrap.stuff is api('chained').wrap('stuff')
-        assert api.more.chaining.stuff is api.more('chaining')('stuff')
-        assert api('expert/chaining/stuff') is not api.expert.chaining.stuff
-        assert api('hello', 'world') is api.hello.world
-        assert api('products', 123) is api.products(123)
+        self.assertIs(self.api.chained.wrap.stuff, self.api('chained').wrap('stuff'))
+        self.assertIs(self.api.more.chaining.stuff, self.api.more('chaining')('stuff'))
+        self.assertIsNot(self.api('expert/chaining/stuff'), self.api.expert.chaining.stuff)
+        self.assertIs(self.api('hello', 'world'), self.api.hello.world)
+        self.assertIs(self.api('products', 123), self.api.products(123))
 
     def test_debugging(self):
-        api.user.get('имя', debug=True)
+        self.api.user.get('имя', debug=True)
 
     def test_response_exceptions(self):
-        self.assertRaises(HTTPError, api.status_404.get)
-        self.assertRaises(HTTPError, api.status_500.get)
+        with self.assertRaises(HTTPError):
+            self.api.status_404.get()
+
+        with self.assertRaises(HTTPError):
+            self.api.status_500.get()
+
         try:
-            api.status_404.get(silent=True)
-            api.status_500.get(silent=True)
+            self.api.status_404.get(silent=True)
+            self.api.status_500.get(silent=True)
         except HTTPError:
             self.fail("Wrap.get() raised an unexpected HTTPError while being "
                       "told to be silent!")
+
+    def test_bunchify_sequence_objects(self):
+        bunch = bunchify([{"a": 1}, {"b": 2}])
+        self.assertIsInstance(bunch[0], Bunch)
+
+    def test_run_from_ipython(self):
+        self.assertEqual(getattr(__builtins__, "__IPYTHON__", False),
+                         run_from_ipython())
 
 
 if __name__ == '__main__':

--- a/tortilla/wrappers.py
+++ b/tortilla/wrappers.py
@@ -177,7 +177,11 @@ class Client(object):
 
         # delay if needed
         if delay > 0:
-            elapsed = time.time() - self._last_request_time
+            t = time.time()
+            if self._last_request_time is None:
+                self._last_request_time = t
+
+            elapsed = t - self._last_request_time
             if elapsed < delay:
                 time.sleep(delay - elapsed)
 


### PR DESCRIPTION
Some improvements in tests to increase code coverage and use Python's unittest assertion style that print better assertion error messages.