### PR TITLE
Correct default value for silent parameter

### DIFF
--- a/tortilla/wrappers.py
+++ b/tortilla/wrappers.py
@@ -91,7 +91,7 @@ class Client(object):
 
     def request(self, method, url, path=(), extension=None, suffix=None,
                 params=None, headers=None, data=None, debug=None,
-                cache_lifetime=None, silent=False, ignore_cache=False,
+                cache_lifetime=None, silent=None, ignore_cache=False,
                 format='json', delay=0.0, **kwargs):
         """Requests a URL and returns a *Bunched* response.
 
@@ -245,7 +245,7 @@ class Wrap(object):
     """
 
     def __init__(self, part, parent=None, headers=None, params=None,
-                 debug=None, cache_lifetime=None, silent=False,
+                 debug=None, cache_lifetime=None, silent=None,
                  extension=None, suffix=None, format=None, cache=None,
                  delay=None):
         if not hasattr(part, "encode"):


### PR DESCRIPTION
Having the default value to silent parameter to "False" obligates the user to pass `silent=True` at every request, since in the method `def request(self, method, *parts, **options):`, we set default values for parameters that are not None. In this case, setdefault was called for silent with value `False` and at the last iteration with value `True`, but as key already existed (was first set as False), this had no effect.